### PR TITLE
Fix an error with empty galleries.

### DIFF
--- a/language/english/galleries_lang.php
+++ b/language/english/galleries_lang.php
@@ -17,6 +17,7 @@ $lang['galleries.install_error']		= 'The module could not be installed.';
 $lang['galleries.already_exist_error']	= 'A gallery with the slug "%s" already exist.';
 $lang['galleries.folder_duplicated_error']	= 'An error occurred! The folder already belongs to a gallery.';
 $lang['galleries.no_gallery_description']	= 'No description has been added yet.';
+$lang['galleries.no_images_error']		= 'The gallery is empty.';
 
 // Labels
 $lang['galleries.galleries_label']			= 'Galleries';

--- a/language/german/galleries_lang.php
+++ b/language/german/galleries_lang.php
@@ -17,6 +17,7 @@ $lang['galleries.install_error']		= 'Das Modul konnte nicht installiert werden.'
 $lang['galleries.already_exist_error']	= 'Eine Galerie mit dem Titel "%s" existiert bereits.';
 $lang['galleries.folder_duplicated_error']	= 'Ein Fehler ist aufgetreten! Das Verzeichnis gehört bereits zu einer Galerie.';
 $lang['galleries.no_gallery_description']	= 'Es wurde bis jetzt noch keine Beschreibung hinzugefügt.';
+$lang['galleries.no_images_error']		= 'Die Galerie enthält keine Bilder.';
 
 // Labels
 $lang['galleries.galleries_label']			= 'Galerien';

--- a/views/admin/form.php
+++ b/views/admin/form.php
@@ -57,10 +57,13 @@
 					<li class="thumbnail-manage <?php echo alternator('', 'even'); ?>">
 						<label for="gallery_thumbnail"><?php echo lang('galleries.thumbnail_label'); ?></label>
 						<div class="input">
-							<?php 
-								if( empty($thumbnails) ) {
+							<?php
+								if( empty($thumbnails) )
+								{
 									echo lang('galleries.no_images_error');
-								} else {
+								} 
+								else
+								{
 									echo form_dropdown('gallery_thumbnail', array(0 => lang('galleries.no_thumb_label')) + $thumbnails, $gallery->thumbnail_id, 'id="gallery_thumbnail"'); 
 								}
 							?>

--- a/views/admin/form.php
+++ b/views/admin/form.php
@@ -57,7 +57,13 @@
 					<li class="thumbnail-manage <?php echo alternator('', 'even'); ?>">
 						<label for="gallery_thumbnail"><?php echo lang('galleries.thumbnail_label'); ?></label>
 						<div class="input">
-							<?php echo form_dropdown('gallery_thumbnail', array(0 => lang('galleries.no_thumb_label')) + $thumbnails, $gallery->thumbnail_id, 'id="gallery_thumbnail"'); ?>
+							<?php 
+								if( empty($thumbnails) ) {
+									echo lang('galleries.no_images_error');
+								} else {
+									echo form_dropdown('gallery_thumbnail', array(0 => lang('galleries.no_thumb_label')) + $thumbnails, $gallery->thumbnail_id, 'id="gallery_thumbnail"'); 
+								}
+							?>
 						</div>
 					</li>
 					

--- a/views/admin/form.php
+++ b/views/admin/form.php
@@ -58,7 +58,7 @@
 						<label for="gallery_thumbnail"><?php echo lang('galleries.thumbnail_label'); ?></label>
 						<div class="input">
 							<?php
-								if( empty($thumbnails) )
+								if(empty($thumbnails))
 								{
 									echo lang('galleries.no_images_error');
 								} 


### PR DESCRIPTION
The + operand produces a fatal error with an empty $thumbnails array. Added a quick fix.
