### PR TITLE
Fixed a bug on public index view's controller

### DIFF
--- a/views/index.php
+++ b/views/index.php
@@ -2,7 +2,7 @@
 
 <div class="galleries_container" id="gallery_index">
 	
-	<?php if ( ! empty($galleries)): foreach ($galleries as $gallery): if (empty($gallery->parent)): ?>
+	<?php if ( ! empty($galleries)): foreach ($galleries as $gallery): if (!empty($gallery->parent)): ?>
 	<div class="gallery clearfix">
 
 		<div class="gallery_heading">


### PR DESCRIPTION
On my fresh install of PyroCMS 2.1.2 Pro. "galleries/index" doesn't
show anything on its index page (although I've uploaded some public
galleries).
